### PR TITLE
Add support for 201S (variant of 200S)

### DIFF
--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -2,6 +2,7 @@ export enum DeviceName {
   Core400SPro = '401S',
   Core400S = '400S',
   Core300S = '300S',
+  Core201S = '201S',
   Core200S = '200S'
 }
 
@@ -28,7 +29,9 @@ const deviceTypes: DeviceType[] = [
     speedLevels: 4
   },
   {
-    isValid: (input: string) => input.includes(DeviceName.Core200S),
+    isValid: (input: string) =>
+      input.includes(DeviceName.Core201S) ||
+      input.includes(DeviceName.Core200S),
     hasAutoMode: false,
     speedMinStep: 25,
     speedLevels: 4


### PR DESCRIPTION
Adds support for the `LAP-C201S-AUSR` device type which appears to be identical to the `Core200S` device type except in model number. These are sold on Amazon.com as a "200S" model, but they're marked as `LAP-C201S-AUSR` on the label. Otherwise appears to work and function the same as a `201S` model.