### PR TITLE
fix(dual200s): filtering out humidifiers

### DIFF
--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -308,9 +308,10 @@ export default class VeSync {
 
         const devices = list
           .filter(
-            ({ deviceType, type }) =>
+            ({ deviceType, type, extension }) =>
               !!deviceTypes.find(({ isValid }) => isValid(deviceType)) &&
-              type === 'wifi-air'
+              type === 'wifi-air' &&
+              extension !== null //The humidifier Dual200S shows as a wifi-air but extension is null, so exclude it
           )
           .map(VeSyncFan.fromResponse(this));
 


### PR DESCRIPTION
I have a [Dual200S](https://levoit.com/products/dual-200s-smart-top-fill-humidifier) which was causing this plugin to crash because it is a "air-purifier" in the vesync api response but with no air quality information.

I fixed this by filtering out devices that do not have the extension information.

Example of the device list output
```json
[
  {
    "deviceRegion": "US",
    "isOwner": true,
    "authKey": null,
    "deviceName": "Office Humidifer",
    "deviceImg": "https://image.vesync.com/defaultImages/Dual_200S_Series/icon_dual200s_humidifier_160.png",
    "cid": "someidobscured",
    "deviceStatus": "on",
    "connectionStatus": "online",
    "connectionType": "WiFi+BTOnboarding+BTNotify",
    "deviceType": "Dual200S",
    "type": "wifi-air",
    "uuid": "asdadsasdasdasd-asdasd-asdasd-asdasdads-asdasdasdasdadasd",
    "configModule": "WiFiBTOnboardingNotify_AirHumidifier_Dual200S_US",
    "macID": "12:34:56:78:91:10",
    "mode": null,
    "speed": null,
    "extension": null,
    "currentFirmVersion": null,
    "subDeviceNo": null,
    "subDeviceType": null,
    "deviceFirstSetupTime": "Nov 7, 2021 10:19:57 PM"
  },
]
```