### PR TITLE
Add support for 301S

### DIFF
--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -3,6 +3,7 @@ export enum DeviceName {
   Core600S = '600S',
   Core401S = '401S',
   Core400S = '400S',
+  Core301S = '301S',
   Core300S = '300S',
   Core201S = '201S',
   Core200S = '200S'
@@ -31,7 +32,9 @@ const deviceTypes: DeviceType[] = [
     hasPM25: true
   },
   {
-    isValid: (input: string) => input.includes(DeviceName.Core300S),
+    isValid: (input: string) => 
+      input.includes(DeviceName.Core301S) ||
+      input.includes(DeviceName.Core300S),
     hasAirQuality: true,
     hasAutoMode: true,
     speedMinStep: 25,


### PR DESCRIPTION
It would appear that some Levoit Core 300S air purifiers that are sold internationally are labelled "301S" internally even though the unit itself remains marketed as the 300S. This might be similar to how there are 201S and 401S.