### PR TITLE
added 602S and 302S models

### DIFF
--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -1,8 +1,10 @@
 export enum DeviceName {
+  Core602S = '602S',
   Core601S = '601S',
   Core600S = '600S',
   Core401S = '401S',
   Core400S = '400S',
+  Core302S = '302S',
   Core301S = '301S',
   Core300S = '300S',
   Core201S = '201S',
@@ -21,6 +23,7 @@ export interface DeviceType {
 const deviceTypes: DeviceType[] = [
   {
     isValid: (input: string) =>
+      input.includes(DeviceName.Core602S) ||
       input.includes(DeviceName.Core601S) ||
       input.includes(DeviceName.Core600S) ||
       input.includes(DeviceName.Core401S) ||
@@ -33,6 +36,7 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) =>
+      input.includes(DeviceName.Core302S) ||
       input.includes(DeviceName.Core301S) ||
       input.includes(DeviceName.Core300S),
     hasAirQuality: true,


### PR DESCRIPTION
there are 602 and 302 models for devices with "plasmapro" features 

added these lines into the devicetypes.ts to let them into homebridge