### PR TITLE
Differentiate between Core200S and Vital200S device types

### DIFF
--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -59,7 +59,7 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) =>
-      input.includes(DeviceName.Core201S) ||
+      (input.includes(DeviceName.Core201S) && !input.includes(DeviceName.Vital200S)) ||
       input.includes(DeviceName.Core200S),
     hasAirQuality: false,
     hasAutoMode: false,


### PR DESCRIPTION
There's a bug in `deviceTypes` where the Vital 200S is treated like a Core 201S, because `DeviceName.Core201S` is a substring of `DeviceName.Vital200S`. This is a simple fix to prevent this.

[As mentioned in this issue](https://github.com/RaresAil/homebridge-levoit-air-purifier/issues/100#issuecomment-2120379466), this causes the Vital 200S to not include the air quality sensor tile, along with other issues.