### PR TITLE
Make model name matching more robust.

### DIFF
--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -32,14 +32,32 @@ export type DeviceCategory = 'Core' | 'Vital';
 
 export type HumidifierDeviceType = Omit<DeviceType, 'hasPM25' | 'hasAirQuality'> & { isHumidifier: true };
 
+/*
+Enforce the name being a whole word within the model. Examples:
+
+  - "V201S" matches "LAP-V201S-WUS"
+  - "201S" does NOT match "LAP-V201S-WUS"
+  - "Dual200S" matches "Dual200S"
+
+Model numbers may vary by region, so not being too restrictive, but simply checking for substrings would cause issues if
+not done in a certain order. For example, checking for Core201S before Vital200S would falsely identify a Vital200S as a
+Core201S as seen with https://github.com/RaresAil/homebridge-levoit-air-purifier/issues/100/. Furthermore, a word
+boundary is used instead of a hyphen (-) to handle the case where the name is 1:1 with the model.
+*/
+const isModelMatch = (model: string, ...names: (DeviceName | HumidifierDeviceName)[]) =>
+  new RegExp(`\\b(${names.join("|")})\\b`).test(model);
+
 const deviceTypes: DeviceType[] = [
   {
     isValid: (input: string) =>
-      input.includes(DeviceName.Core602S) ||
-      input.includes(DeviceName.Core601S) ||
-      input.includes(DeviceName.Core600S) ||
-      input.includes(DeviceName.Core401S) ||
-      input.includes(DeviceName.Core400S),
+      isModelMatch(
+        input,
+        DeviceName.Core602S,
+        DeviceName.Core601S,
+        DeviceName.Core600S,
+        DeviceName.Core401S,
+        DeviceName.Core400S
+      ),
     hasAirQuality: true,
     hasAutoMode: true,
     speedMinStep: 20,
@@ -48,9 +66,12 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) =>
-      input.includes(DeviceName.Core302S) ||
-      input.includes(DeviceName.Core301S) ||
-      input.includes(DeviceName.Core300S),
+      isModelMatch(
+        input,
+        DeviceName.Core302S,
+        DeviceName.Core301S,
+        DeviceName.Core300S
+      ),
     hasAirQuality: true,
     hasAutoMode: true,
     speedMinStep: 25,
@@ -59,8 +80,11 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) =>
-      input.includes(DeviceName.Core201S) ||
-      input.includes(DeviceName.Core200S),
+      isModelMatch(
+        input,
+        DeviceName.Core201S,
+        DeviceName.Core200S
+      ),
     hasAirQuality: false,
     hasAutoMode: false,
     speedMinStep: 25,
@@ -69,8 +93,11 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) =>
-      input.includes(DeviceName.Vital100S) ||
-      input.includes(DeviceName.Vital200S),
+      isModelMatch(
+        input,
+        DeviceName.Vital100S,
+        DeviceName.Vital200S
+      ),
     hasAirQuality: true,
     hasAutoMode: true,
     speedMinStep: 25,
@@ -82,8 +109,11 @@ const deviceTypes: DeviceType[] = [
 export const humidifierDeviceTypes: HumidifierDeviceType[] = [
   {
     isValid: (input: string) =>
-      input.includes(HumidifierDeviceName.Dual200S) ||
-      input.includes(HumidifierDeviceName.Dual200SLeg),
+      isModelMatch(
+        input,
+        HumidifierDeviceName.Dual200S,
+        HumidifierDeviceName.Dual200SLeg
+      ),
     hasAutoMode: true,
     speedMinStep: 50,
     speedLevels: 2,


### PR DESCRIPTION
As others have reported, I noticed integration with my Vital 200S air purifier was not working as expected with this plugin. Upon debugging, the model name matching behavior was incorrectly characterizing the Vital 200S as a Core 201S because the Core 201S name `201S` is a substring of the Vital 200S one `V201S` and is checked first. This resulted in incorrect configuration and missing information like air quality and certain controls within the Apple Home app.

Rather than checking if the device names are just substrings of the model strings reported by the VeSync API, a simple regex is used to ensure the name is a whole word within the model string. This ensures that:

- Matching works as expected independent of evaluation order
- No dependencies between names exist when matching
- No rigid schema is enforced on the model strings, as they are likely to vary
- The case where the name is the entire model string is covered

I've tested this locally with my Vital 100S and 200S air purifiers and confirmed the 200S missing information is now populated while not breaking the 100S.

Thanks for the fantastic work on this plugin!